### PR TITLE
Remove unecessary links to OpenGL and GLUT libraries

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,2 +1,2 @@
 PKG_CXXFLAGS = -I/usr/local/Cellar/sdl2/2.0.16/include/ -I/opt/X11/include
-PKG_LIBS= -framework OpenGL -framework GLUT -lSDL2
+PKG_LIBS= -lSDL2


### PR DESCRIPTION
SDL2 includes OpenGL functionality, so we don't need to separately link against it or GLUT to get the SDL_GL_* functions to work.